### PR TITLE
Rjust identity point with zeros and decode with length parameter

### DIFF
--- a/lib/poly_pseudo/identity.rb
+++ b/lib/poly_pseudo/identity.rb
@@ -18,7 +18,8 @@ module PolyPseudo
           .add(point_2)
           .make_affine!
 
-      @identity = Util.oaep_decode(identity_point.x.to_s(2)).slice(3, 10).force_encoding("UTF-8").strip
+      decoded = Util.oaep_decode(identity_point.x.to_s(2).rjust(40, "\x00"))
+      @identity = decoded.slice(3, decoded[2].ord).force_encoding("UTF-8")
     end
 
     def identity

--- a/lib/poly_pseudo/util.rb
+++ b/lib/poly_pseudo/util.rb
@@ -21,12 +21,13 @@ module PolyPseudo
     def oaep_decode(em, p = '', hlen = 10)
       raise 'message is too short!' if em.length < hlen * 2 + 1
 
-      maskedSeed = em[0...hlen]
-      maskedDB   = em[hlen..-1]
+      raise 'Y should be zero!' unless em[0] == "\x00"
+      maskedSeed = em[1..hlen]
+      maskedDB   = em[(hlen+1)..-1]
 
       seedMask = mgf1 maskedDB, hlen
       seed     = xor maskedSeed, seedMask
-      dbMask   = mgf1 seed, em.size - hlen
+      dbMask   = mgf1 seed, em.size - hlen - 1
       db       = xor maskedDB, dbMask
       pHash    = Digest::SHA384.digest(p)[0...hlen]
 


### PR DESCRIPTION
According to the [specification](https://tools.ietf.org/html/rfc8017#section-7.1.2) OAEP message is divided in three parts
```
EM = Y || maskedSeed || maskedDB
```
And `Y` should be zero. 

Also the [Uniforme Set van Eisen (page 107)](https://www.rijksoverheid.nl/binaries/rijksoverheid/documenten/rapporten/2016/12/15/uniforme-set-van-eisen/uniforme-set-van-eisen.pdf) specifies that you take the full 40 bytes representation. This makes senses, because now the zero is always added. Next to this, it also works for points that are only 38 bytes long, which occurs sometimes and is a bug in the current version.

Also instead of the `strip`, you can use the third character to determine the length of the identifier.
